### PR TITLE
Add PaymentController unit test

### DIFF
--- a/src/test/java/org/ecommerce/ecommerceapi/modules/payment/controller/PaymentControllerTest.java
+++ b/src/test/java/org/ecommerce/ecommerceapi/modules/payment/controller/PaymentControllerTest.java
@@ -1,0 +1,64 @@
+package org.ecommerce.ecommerceapi.modules.payment.controller;
+
+import org.ecommerce.ecommerceapi.modules.payment.dto.PaymentRequestDTO;
+import org.ecommerce.ecommerceapi.modules.payment.dto.PaymentResponseDTO;
+import org.ecommerce.ecommerceapi.modules.payment.service.PaymentService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class PaymentControllerTest {
+
+    @InjectMocks
+    private PaymentController paymentController;
+
+    @Mock
+    private PaymentService paymentService;
+
+    @Mock
+    private Authentication authentication;
+
+    private PaymentRequestDTO requestDTO;
+    private PaymentResponseDTO responseDTO;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        requestDTO = new PaymentRequestDTO();
+        requestDTO.setPedidoId(1L);
+        requestDTO.setValor(BigDecimal.TEN);
+
+        responseDTO = new PaymentResponseDTO();
+        responseDTO.setId(1L);
+        responseDTO.setPedidoId(1L);
+        responseDTO.setValor(BigDecimal.TEN);
+    }
+
+    @Test
+    void testPagar() {
+        when(authentication.getName()).thenReturn("1");
+        when(paymentService.pagar(any(PaymentRequestDTO.class), eq(1L))).thenReturn(responseDTO);
+
+        ResponseEntity<PaymentResponseDTO> response = paymentController.pagar(requestDTO, authentication);
+
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertEquals(responseDTO, response.getBody());
+
+        ArgumentCaptor<PaymentRequestDTO> captor = ArgumentCaptor.forClass(PaymentRequestDTO.class);
+        verify(paymentService, times(1)).pagar(captor.capture(), eq(1L));
+        assertEquals(requestDTO.getPedidoId(), captor.getValue().getPedidoId());
+        assertEquals(requestDTO.getValor(), captor.getValue().getValor());
+    }
+}

--- a/src/test/java/org/ecommerce/ecommerceapi/modules/payment/dto/PaymentRequestDTOTest.java
+++ b/src/test/java/org/ecommerce/ecommerceapi/modules/payment/dto/PaymentRequestDTOTest.java
@@ -1,0 +1,20 @@
+package org.ecommerce.ecommerceapi.modules.payment.dto;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PaymentRequestDTOTest {
+
+    @Test
+    void testGettersAndSetters() {
+        PaymentRequestDTO dto = new PaymentRequestDTO();
+        dto.setPedidoId(1L);
+        dto.setValor(BigDecimal.TEN);
+
+        assertEquals(1L, dto.getPedidoId());
+        assertEquals(BigDecimal.TEN, dto.getValor());
+    }
+}

--- a/src/test/java/org/ecommerce/ecommerceapi/modules/payment/dto/PaymentResponseDTOTest.java
+++ b/src/test/java/org/ecommerce/ecommerceapi/modules/payment/dto/PaymentResponseDTOTest.java
@@ -1,0 +1,30 @@
+package org.ecommerce.ecommerceapi.modules.payment.dto;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PaymentResponseDTOTest {
+
+    @Test
+    void testGettersSettersAndToString() {
+        PaymentResponseDTO dto = new PaymentResponseDTO();
+        LocalDateTime now = LocalDateTime.now();
+        dto.setId(1L);
+        dto.setPedidoId(2L);
+        dto.setValor(BigDecimal.TEN);
+        dto.setDataPagamento(now);
+
+        assertEquals(1L, dto.getId());
+        assertEquals(2L, dto.getPedidoId());
+        assertEquals(BigDecimal.TEN, dto.getValor());
+        assertEquals(now, dto.getDataPagamento());
+
+        String str = dto.toString();
+        assertNotNull(str);
+        assertTrue(str.contains("pedidoId"));
+    }
+}

--- a/src/test/java/org/ecommerce/ecommerceapi/modules/payment/entity/PaymentTest.java
+++ b/src/test/java/org/ecommerce/ecommerceapi/modules/payment/entity/PaymentTest.java
@@ -1,0 +1,60 @@
+package org.ecommerce.ecommerceapi.modules.payment.entity;
+
+import org.ecommerce.ecommerceapi.modules.pedido.entity.Pedido;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PaymentTest {
+
+    private Payment payment;
+    private Pedido pedido;
+    private LocalDateTime now;
+
+    @BeforeEach
+    void setUp() {
+        pedido = new Pedido();
+        pedido.setId(1L);
+
+        payment = new Payment();
+        payment.setId(1L);
+        payment.setPedido(pedido);
+        payment.setValor(BigDecimal.TEN);
+        now = LocalDateTime.now();
+        payment.setDataPagamento(now);
+    }
+
+    @Test
+    void testGettersAndSetters() {
+        assertEquals(1L, payment.getId());
+        assertEquals(pedido, payment.getPedido());
+        assertEquals(BigDecimal.TEN, payment.getValor());
+        assertEquals(now, payment.getDataPagamento());
+    }
+
+    @Test
+    void testEqualsAndHashCode() {
+        Payment other = new Payment();
+        other.setId(1L);
+        other.setPedido(pedido);
+        other.setValor(BigDecimal.TEN);
+        other.setDataPagamento(now);
+
+        assertEquals(payment, other);
+        assertEquals(payment.hashCode(), other.hashCode());
+
+        other.setValor(BigDecimal.ONE);
+        assertNotEquals(payment, other);
+    }
+
+    @Test
+    void testToString() {
+        String str = payment.toString();
+        assertNotNull(str);
+        assertTrue(str.contains("id=1"));
+    }
+}

--- a/src/test/java/org/ecommerce/ecommerceapi/modules/payment/repository/PaymentRepositoryTest.java
+++ b/src/test/java/org/ecommerce/ecommerceapi/modules/payment/repository/PaymentRepositoryTest.java
@@ -1,0 +1,65 @@
+package org.ecommerce.ecommerceapi.modules.payment.repository;
+
+import org.ecommerce.ecommerceapi.modules.cliente.entities.ClienteEntity;
+import org.ecommerce.ecommerceapi.modules.cliente.repositories.ClienteRepository;
+import org.ecommerce.ecommerceapi.modules.payment.entity.Payment;
+import org.ecommerce.ecommerceapi.modules.pedido.entity.Pedido;
+import org.ecommerce.ecommerceapi.modules.pedido.repository.PedidoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class PaymentRepositoryTest {
+
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    @Autowired
+    private PedidoRepository pedidoRepository;
+
+    @Autowired
+    private ClienteRepository clienteRepository;
+
+    @BeforeEach
+    void setUp() {
+        paymentRepository.deleteAll();
+        pedidoRepository.deleteAll();
+        clienteRepository.deleteAll();
+    }
+
+    @Test
+    void testFindByPedidoId() {
+        ClienteEntity cliente = new ClienteEntity();
+        cliente.setUsername("cliente1");
+        cliente.setEmail("cliente1@test.com");
+        cliente.setNome("Cliente");
+        cliente.setSenha("senha123");
+        cliente.setAtivo(true);
+        cliente = clienteRepository.save(cliente);
+
+        Pedido pedido = new Pedido();
+        pedido.setCliente(cliente);
+        pedido.setCancelado(false);
+        pedido.setTotal(BigDecimal.valueOf(100));
+        pedido.setDateCreate(LocalDateTime.now());
+        pedido = pedidoRepository.save(pedido);
+
+        Payment payment = new Payment();
+        payment.setPedido(pedido);
+        payment.setValor(BigDecimal.valueOf(100));
+        payment.setDataPagamento(LocalDateTime.now());
+        paymentRepository.save(payment);
+
+        List<Payment> list = paymentRepository.findByPedidoId(pedido.getId());
+        assertEquals(1, list.size());
+        assertEquals(BigDecimal.valueOf(100), list.get(0).getValor());
+    }
+}

--- a/src/test/java/org/ecommerce/ecommerceapi/modules/payment/service/PaymentServiceTest.java
+++ b/src/test/java/org/ecommerce/ecommerceapi/modules/payment/service/PaymentServiceTest.java
@@ -1,0 +1,105 @@
+package org.ecommerce.ecommerceapi.modules.payment.service;
+
+import org.ecommerce.ecommerceapi.modules.cliente.entities.ClienteEntity;
+import org.ecommerce.ecommerceapi.modules.payment.dto.PaymentRequestDTO;
+import org.ecommerce.ecommerceapi.modules.payment.dto.PaymentResponseDTO;
+import org.ecommerce.ecommerceapi.modules.payment.entity.Payment;
+import org.ecommerce.ecommerceapi.modules.payment.repository.PaymentRepository;
+import org.ecommerce.ecommerceapi.modules.pedido.entity.Pedido;
+import org.ecommerce.ecommerceapi.modules.pedido.repository.PedidoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class PaymentServiceTest {
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private PedidoRepository pedidoRepository;
+
+    @InjectMocks
+    private PaymentService paymentService;
+
+    private Pedido pedido;
+    private PaymentRequestDTO requestDTO;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        ClienteEntity cliente = new ClienteEntity();
+        cliente.setId(1L);
+
+        pedido = new Pedido();
+        pedido.setId(1L);
+        pedido.setCliente(cliente);
+        pedido.setTotal(BigDecimal.TEN);
+        pedido.setCancelado(false);
+
+        requestDTO = new PaymentRequestDTO();
+        requestDTO.setPedidoId(1L);
+        requestDTO.setValor(BigDecimal.TEN);
+    }
+
+    @Test
+    void testPagarSucesso() {
+        Payment payment = new Payment();
+        payment.setId(2L);
+        payment.setPedido(pedido);
+        payment.setValor(BigDecimal.TEN);
+        payment.setDataPagamento(LocalDateTime.now());
+
+        when(pedidoRepository.findById(1L)).thenReturn(Optional.of(pedido));
+        when(paymentRepository.save(any(Payment.class))).thenReturn(payment);
+
+        PaymentResponseDTO response = paymentService.pagar(requestDTO, 1L);
+
+        assertNotNull(response);
+        assertEquals(2L, response.getId());
+        assertEquals(1L, response.getPedidoId());
+        assertEquals(BigDecimal.TEN, response.getValor());
+    }
+
+    @Test
+    void testPagarPedidoNaoEncontrado() {
+        when(pedidoRepository.findById(1L)).thenReturn(Optional.empty());
+        assertThrows(RuntimeException.class, () -> paymentService.pagar(requestDTO, 1L));
+    }
+
+    @Test
+    void testPagarClienteInvalido() {
+        ClienteEntity outro = new ClienteEntity();
+        outro.setId(2L);
+        pedido.setCliente(outro);
+        when(pedidoRepository.findById(1L)).thenReturn(Optional.of(pedido));
+
+        assertThrows(RuntimeException.class, () -> paymentService.pagar(requestDTO, 1L));
+    }
+
+    @Test
+    void testPagarPedidoCancelado() {
+        pedido.setCancelado(true);
+        when(pedidoRepository.findById(1L)).thenReturn(Optional.of(pedido));
+
+        assertThrows(RuntimeException.class, () -> paymentService.pagar(requestDTO, 1L));
+    }
+
+    @Test
+    void testPagarValorInvalido() {
+        requestDTO.setValor(BigDecimal.ONE);
+        when(pedidoRepository.findById(1L)).thenReturn(Optional.of(pedido));
+
+        assertThrows(RuntimeException.class, () -> paymentService.pagar(requestDTO, 1L));
+    }
+}


### PR DESCRIPTION
## Summary
- add unit test for PaymentController `pagar` route
- cover PaymentService logic and error conditions
- add entity, DTO, and repository tests for Payment module

## Testing
- `mvn test` *(fails: Non-resolvable parent POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685aeb1af010833287e1e5b6de1e9cf5