### PR TITLE
Add local Docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ spring.jpa.show-sql=true
 ./mvnw clean package -DskipTests
 docker-compose up --build
 ```
+Após a inicialização, acesse [http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html) para testar a API localmente.
 
 ## 🧪 Como executar os testes
 


### PR DESCRIPTION
## Summary
- add instructions to run the project locally using Docker and access Swagger UI

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685c080aab948332b73b59f72a31e7c7